### PR TITLE
kit.paths.base defined based on NODE_ENV; paths.resolve() used to utilize it

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import favicon from "$lib/assets/favicon.svg";
-
+  import { resolve } from "$app/paths";
   let { children } = $props();
 </script>
 
@@ -10,8 +10,8 @@
 
 <header>
   <nav>
-    <a href="/">home</a>
-    <a href="/posts">posts</a>
+    <a href={resolve("/")}>home</a>
+    <a href={resolve("/posts")}>posts</a>
   </nav>
   <h1>SvelteKit playground</h1>
   <p>SvelteKit playground</p>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  import { resolve } from "$app/paths";
+</script>
+
 <h1>SvelteKit playground</h1>
 
-<p><a href="posts/">posts</a></p>
+<p><a href={resolve("/posts")}>posts</a></p>

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { resolve } from "$app/paths";
   import type { PageProps } from "./$types";
   let { data }: PageProps = $props();
 </script>
@@ -8,7 +9,7 @@
 <ul>
   {#each data.posts as post (post.slug)}
     <li>
-      <a href={`/posts/${post.slug}`}
+      <a href={resolve(`/posts/${post.slug}`)}
         >{post.meta.title} - {post.meta.date.toISOString()}</a
       >
     </li>

--- a/src/routes/posts/[slug]/+page.svelte
+++ b/src/routes/posts/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { resolve } from "$app/paths";
   import type { PageProps } from "./$types";
   let { data }: PageProps = $props();
 </script>
@@ -8,7 +9,8 @@
     <tr><td>title</td><td>{data.meta.title}</td></tr>
     <tr><td>date</td><td>{data.meta.date.toISOString()}</td></tr>
     <tr
-      ><td>url</td><td><a href="/posts/{data.slug}">/posts/{data.slug}</a></td
+      ><td>url</td><td
+        ><a href={resolve(`/posts/${data.slug}`)}>/posts/{data.slug}</a></td
       ></tr
     >
   </tbody>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,11 @@ const config = {
 			fallback: undefined,
 			precompress: false,
 			strict: true
-		})
+		}),
+		paths: {
+			// https://vite.dev/guide/env-and-mode.html#modes
+			base: process.env.NODE_ENV === "production" ? "/sveltekit-playground" : "",
+		}
 	}
 };
 


### PR DESCRIPTION
Fixed:

- **svelte.config.js → config.kit.paths.base** defined depending on **process.env.NODE_ENV** value
- **$app/paths.resolve()** used to calculate absolute paths based on **config.kit.paths.base** value