### PR TITLE
DarkMode: 'html.class=dark' is now used instead of 'body.class=dark'

### DIFF
--- a/src/lib/components/DarkMode/DarkMode.svelte
+++ b/src/lib/components/DarkMode/DarkMode.svelte
@@ -24,8 +24,8 @@
   );
   $effect(() => localStorage.setItem("theme", usrChoice));
   $effect(() => {
-    if (lightMode) document.body.classList.remove("dark");
-    else document.body.classList.add("dark");
+    if (lightMode) document.documentElement.classList.remove("dark");
+    else document.documentElement.classList.add("dark");
   });
   $effect(() => {
     const m = window.matchMedia("(prefers-color-scheme: light)");


### PR DESCRIPTION
It's done: **html.class=dark** is now used instead of **body.class=dark**